### PR TITLE
[화면 구현] 홈 및 상품 검색 관련 페이지 구현

### DIFF
--- a/frontend/src/components/common/BottomTab.tsx
+++ b/frontend/src/components/common/BottomTab.tsx
@@ -4,7 +4,7 @@ import { FaRegUser } from "react-icons/fa";
 import { IoMdQrScanner } from "react-icons/io";
 
 const NAV_ITEMS = [
-  { path: "/", icon: BiHomeAlt },
+  { path: "/home", icon: BiHomeAlt },
   { path: "/add", icon: IoMdQrScanner },
   { path: "/profile", icon: FaRegUser },
 ] as const;

--- a/frontend/src/components/common/Card.tsx
+++ b/frontend/src/components/common/Card.tsx
@@ -48,6 +48,11 @@ const CARD_VARIANTS: Record<string, VariantStyles> = {
     image: "h-32 w-32 rounded-lg",
     title: "mt-1 pl-0.5 text-sm",
   },
+  big: {
+    container: "mr-1 inline-block w-full truncate",
+    image: "h-full w-full rounded-lg",
+    title: "mt-1 pl-0.5 text-sm",
+  },
 } as const;
 
 type CardProps = {

--- a/frontend/src/components/common/ImageSlider.tsx
+++ b/frontend/src/components/common/ImageSlider.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useRef, useEffect } from "react";
+import { IoMdArrowBack, IoMdArrowForward } from "react-icons/io";
+
+type ImageSliderProps = {
+  images: string[];
+};
+
+export const ImageSlider = ({ images }: ImageSliderProps) => {
+  const [currentIndex, setCurrentIndex] = useState(1);
+  const [startX, setStartX] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const transitionRef = useRef(true);
+
+  const extendedImages = [images[images.length - 1], ...images, images[0]];
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setStartX(e.touches[0].clientX);
+    setIsDragging(true);
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    setStartX(e.clientX);
+    setIsDragging(true);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging) return;
+    const currentX = e.touches[0].clientX;
+    handleDrag(currentX);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging) return;
+    const currentX = e.clientX;
+    handleDrag(currentX);
+  };
+
+  const handleDragEnd = () => {
+    setIsDragging(false);
+  };
+
+  const handleNextImage = () => {
+    setCurrentIndex((prevIndex) => prevIndex + 1);
+  };
+
+  const handlePreviousImage = () => {
+    setCurrentIndex((prevIndex) => prevIndex - 1);
+  };
+
+  const handleDrag = (currentX: number) => {
+    const diff = startX - currentX;
+    if (Math.abs(diff) > 50) {
+      if (diff > 0) {
+        handleNextImage();
+      } else {
+        handlePreviousImage();
+      }
+      setIsDragging(false);
+    }
+  };
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.style.transition = transitionRef.current
+        ? "transform 300ms ease-out"
+        : "";
+      containerRef.current.style.transform = `translateX(-${currentIndex * 100}%)`;
+    }
+  }, [currentIndex]);
+
+  useEffect(() => {
+    if (currentIndex === 0) {
+      transitionRef.current = false;
+      setTimeout(() => {
+        setCurrentIndex(extendedImages.length - 2);
+      }, 300);
+    } else if (currentIndex === extendedImages.length - 1) {
+      transitionRef.current = false;
+      setTimeout(() => {
+        setCurrentIndex(1);
+      }, 300);
+    } else {
+      transitionRef.current = true;
+    }
+  }, [currentIndex, extendedImages.length]);
+
+  return (
+    <div className="relative w-full overflow-hidden">
+      <div
+        ref={containerRef}
+        className="flex cursor-pointer"
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleDragEnd}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleDragEnd}
+        onMouseLeave={handleDragEnd}
+      >
+        {extendedImages.map((image, index) => (
+          <div key={index} className="h-96 w-full flex-shrink-0 rounded-lg p-4">
+            <img
+              src={image}
+              alt={`이미지 ${index}`}
+              className="pointer-events-none h-full w-full select-none rounded-md object-cover"
+            />
+          </div>
+        ))}
+      </div>
+      <div className="absolute bottom-7 left-1/2 flex -translate-x-1/2 space-x-2">
+        {images.map((_, index) => (
+          <button
+            key={index}
+            className={`h-2 w-2 rounded-full ${
+              index === currentIndex - 1 ? "bg-primary" : "bg-darkBase"
+            }`}
+            onClick={() => setCurrentIndex(index + 1)}
+          />
+        ))}
+      </div>
+      <button
+        className="absolute left-5 top-1/2 -translate-y-1/2 rounded-full bg-base p-2"
+        onClick={handlePreviousImage}
+      >
+        <IoMdArrowBack />
+      </button>
+      <button
+        className="absolute right-5 top-1/2 -translate-y-1/2 rounded-full bg-base p-2"
+        onClick={handleNextImage}
+      >
+        <IoMdArrowForward />
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/common/PhotoUploader.tsx
+++ b/frontend/src/components/common/PhotoUploader.tsx
@@ -83,7 +83,10 @@ export const PhotoUploader: React.FC<PhotoUploaderProps> = ({
             </span>
           </button>
           {photos.map((photo, i) => (
-            <div key={photo.preview} className="relative mr-2 flex-shrink-0">
+            <div
+              key={photo.preview}
+              className="relative mr-2 flex-shrink-0 scrollbar-hide"
+            >
               <div className="relative h-20 w-20">
                 <img
                   src={photo.preview}
@@ -91,7 +94,7 @@ export const PhotoUploader: React.FC<PhotoUploaderProps> = ({
                   className="absolute inset-0 h-full w-full rounded-lg object-cover"
                 />
                 <button
-                  className="absolute -right-2 -top-2 rounded-full border border-darkBase bg-white p-2 text-darkBase"
+                  className="absolute -right-2 -top-2 rounded-full border border-darkBase bg-white p-1 text-darkBase"
                   onClick={() => handleDeletePhoto(i)}
                 >
                   <IoClose className="text-darkBase" />

--- a/frontend/src/components/common/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar.tsx
@@ -1,0 +1,45 @@
+import React, { useState, useRef, useEffect } from "react";
+import { Input } from "./Input";
+import { IoIosSearch } from "react-icons/io";
+
+type SearchBarProps = {
+  placeholder?: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSearch: () => void;
+};
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  placeholder,
+  value,
+  onChange,
+  onSearch,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onSearch();
+    inputRef.current?.blur();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="relative w-full">
+      <Input
+        ref={inputRef}
+        name="search"
+        variant="full"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-12 w-full rounded-full bg-gray-100 py-3 pl-6 pr-10 text-gray-700 shadow-md"
+      />
+      <button
+        type="submit"
+        className="absolute inset-y-0 right-4 flex cursor-pointer items-center bg-transparent"
+      >
+        <IoIosSearch className="text-xl text-gray-400" />
+      </button>
+    </form>
+  );
+};

--- a/frontend/src/components/common/Tag.tsx
+++ b/frontend/src/components/common/Tag.tsx
@@ -2,27 +2,52 @@ import React from "react";
 import clsx from "clsx";
 
 const TAG_VARIANTS = {
-  default: "px-3 py-2 rounded-full text-sm font-medium",
+  default: "px-3 py-2 rounded-full text-sm font-medium select-none",
   primary: "bg-primary text-white",
   green: "bg-green text-white",
   red: "bg-red text-white",
+  gray: "bg-darkBase text-white",
+  select: "cursor-pointer hover:opacity-80",
 } as const;
 
 type TagProps = {
   className?: string;
   variant?: keyof typeof TAG_VARIANTS;
   content: string;
+  value?: string; // 서버 전송 값
+  isSelectable?: boolean; // 선택 가능한지
+  isSelected?: boolean;
+  onClick?: (value: string) => void;
 };
 
 export const Tag: React.FC<TagProps> = ({
   className,
   variant = "primary",
   content,
+  value,
+  isSelectable = false,
+  isSelected = false,
+  onClick,
 }) => {
+  const tagClassName = clsx(
+    TAG_VARIANTS.default,
+    isSelectable && TAG_VARIANTS.select,
+    isSelectable
+      ? isSelected
+        ? TAG_VARIANTS.primary
+        : TAG_VARIANTS.gray
+      : TAG_VARIANTS[variant],
+    className,
+  );
+
+  const handleClick = () => {
+    if (isSelectable && onClick && value !== undefined && !isSelected) {
+      onClick(value);
+    }
+  };
+
   return (
-    <span
-      className={clsx(TAG_VARIANTS.default, TAG_VARIANTS[variant], className)}
-    >
+    <span className={tagClassName} onClick={handleClick}>
       {content}
     </span>
   );

--- a/frontend/src/mocks/store.ts
+++ b/frontend/src/mocks/store.ts
@@ -1,0 +1,86 @@
+import { Store } from "../types/store";
+
+export const stores: Store[] = [
+  {
+    id: "1",
+    title: "서울 핫플 팝업 스토어",
+    imageSrc:
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    imgScrList: [
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://www.nintendo.co.kr/character/kirby/assets/img/about/characters-kirby.png",
+      "https://i.namu.wiki/i/wXGU6DZbHowc6IB0GYPJpcmdDkLO3TW3MHzjg63jcTJvIzaBKhYqR0l9toBMHTv2OSU4eFKfPOlfrSQpymDJlA.webp",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://www.nintendo.co.kr/character/kirby/assets/img/about/characters-kirby.png",
+      "https://i.namu.wiki/i/wXGU6DZbHowc6IB0GYPJpcmdDkLO3TW3MHzjg63jcTJvIzaBKhYqR0l9toBMHTv2OSU4eFKfPOlfrSQpymDJlA.webp",
+    ],
+    location: "서울 강남구",
+    description: "운영시간 10:30-20:00",
+    startDate: "2024-09-01",
+    endDate: "2024-09-30",
+  },
+  {
+    id: "2",
+    title: "브랜드 X 콜라보 팝업",
+    imageSrc:
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    imgScrList: [
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    ],
+    location: "서울 홍대입구",
+    description: "운영시간 10:30-20:00",
+    startDate: "2024-08-15",
+    endDate: "2024-09-15",
+  },
+  {
+    id: "3",
+    title: "신제품 런칭 팝업 스토어",
+    imageSrc:
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    imgScrList: [
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    ],
+    location: "부산 해운대구",
+    description: "운영시간 10:30-20:00",
+    startDate: "2024-10-01",
+    endDate: "2024-10-31",
+  },
+  {
+    id: "4",
+    title: "아티스트 전시 팝업",
+    imageSrc:
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    imgScrList: [
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    ],
+    location: "인천 송도",
+    description: "운영시간 10:30-20:00",
+    startDate: "2024-09-20",
+    endDate: "2024-10-20",
+  },
+  {
+    id: "5",
+    title: "계절 한정 팝업 스토어",
+    imageSrc:
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    imgScrList: [
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+      "https://shopping-phinf.pstatic.net/main_8451971/84519715566.3.jpg?type=f300",
+    ],
+    location: "제주 서귀포시",
+    description: "운영시간 10:30-20:00",
+    startDate: "2024-11-01",
+    endDate: "2024-12-31",
+  },
+];
+
+export const getStores = (): Store[] => {
+  return stores;
+};

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Layout } from "../components/common/Layout";
+import { Card } from "../components/common/Card";
+import { getStores } from "../mocks/store";
+import { IoIosSearch } from "react-icons/io";
+import { Blob_2 } from "../components/common/Background/Blob_2";
+import { Blob_1 } from "../components/common/Background/Blob_1";
+
+const Home = () => {
+  const navigate = useNavigate();
+  const PROFILE_IMG =
+    "https://i.namu.wiki/i/wXGU6DZbHowc6IB0GYPJpcmdDkLO3TW3MHzjg63jcTJvIzaBKhYqR0l9toBMHTv2OSU4eFKfPOlfrSQpymDJlA.webp";
+  const [userName, setUserName] = useState("팝콘");
+  const stores = getStores();
+
+  const handleSearchClick = () => {
+    navigate("/search");
+  };
+
+  const handleStoreDetail = (id: string) => {
+    navigate(`/store/detail/${id}`);
+  };
+
+  return (
+    <Layout>
+      <div className="flex min-h-screen flex-col">
+        {/* 배경 박스들 */}
+        <div className="relative">
+          <div className="absolute right-[-130px] top-[-122px] z-10">
+            <Blob_1 />
+          </div>
+          <div className="absolute right-[-140px] top-[-60px]">
+            <Blob_2 />
+          </div>
+        </div>
+        {/* 프로필 */}
+        <div className="my-12 p-4">
+          <div className="flex-shrink-0">
+            <img
+              src={PROFILE_IMG}
+              className="mb-2 h-12 w-12 rounded-full border object-cover"
+              alt="Profile image"
+            />
+          </div>
+          <div className="text-3xl font-bold">
+            안녕하세요, <br />
+            <span className="text-primary">{userName}</span> 님
+          </div>
+        </div>
+        {/* 인기 스토어 */}
+        <div className="z-10">
+          <h3 className="p-2 text-lg font-semibold">인기 스토어</h3>
+          <div className="flex overflow-x-auto whitespace-nowrap pb-4 pl-2 scrollbar-hide">
+            {stores.map((store) => (
+              <div
+                key={store.id}
+                className="mr-1 flex-shrink-0 cursor-pointer"
+                onClick={() => handleStoreDetail(store.id)}
+              >
+                <Card
+                  variant="mini"
+                  title={store.title}
+                  imageSrc={store.imageSrc}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+        {/* 스토어 찾기 */}
+        <div>
+          <h3 className="mt-2 p-2 text-lg font-semibold">스토어 찾기</h3>
+          <div
+            className="relative w-full cursor-pointer"
+            onClick={handleSearchClick}
+          >
+            <div className="mb-4 h-12 w-full rounded-full bg-gray-100 py-3 pl-6 pr-10 text-gray-400 shadow-md">
+              스토어를 검색해보세요
+            </div>
+            <div className="absolute inset-y-0 right-4 flex items-center">
+              <IoIosSearch className="text-xl text-gray-400" />
+            </div>
+          </div>
+          <div className="flex overflow-x-auto whitespace-nowrap pb-4 pl-2 scrollbar-hide">
+            {stores.map((store) => (
+              <div
+                key={store.id}
+                className="mr-1 flex-shrink-0 cursor-pointer"
+                onClick={() => handleStoreDetail(store.id)}
+              >
+                <Card
+                  variant="mini"
+                  title={store.title}
+                  imageSrc={store.imageSrc}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default Home;

--- a/frontend/src/pages/StoreDetail.tsx
+++ b/frontend/src/pages/StoreDetail.tsx
@@ -1,0 +1,82 @@
+import { useState, useEffect } from "react";
+import { Layout } from "../components/common/Layout";
+import { getStores } from "../mocks/store";
+import { ImageSlider } from "../components/common/ImageSlider";
+import { IoLocationOutline, IoTimeOutline } from "react-icons/io5";
+import { Tag } from "../components/common/Tag";
+import { Card } from "../components/common/Card";
+
+const StoreDetail = () => {
+  const stores = getStores();
+  const store = getStores()[0];
+
+  const handleProductDetail = (id: string) => {};
+
+  return (
+    <Layout>
+      <div className="flex min-h-screen flex-col">
+        <ImageSlider images={store.imgScrList} />
+        <div className="px-2">
+          <div className="flex items-center justify-between">
+            <h1 className="mt-2 text-3xl font-bold">{store.title}</h1>
+          </div>
+          <div className="my-3">
+            <Tag className="mr-1" content="#태그 1" />
+            <Tag className="mr-1" content="#태그 2" />
+            <Tag content="#태그 3" />
+          </div>
+          <div className="flex flex-row">
+            <p className="mt-2 text-sm text-gray-400">{store.startDate} -</p>
+            <p className="mt-2 text-sm text-gray-400">{store.endDate}</p>
+          </div>
+          <p className="mt-2 flex items-center text-sm">
+            <IoLocationOutline className="mr-1" />
+            {store?.location}
+          </p>
+          <div className="mb-4 mt-4">
+            <h2 className="mb-2 text-lg font-semibold">운영 시간</h2>
+            <div className="space-y-1">
+              <p className="flex items-center text-sm">
+                <IoTimeOutline className="mr-1" />
+                월-금: 11:00 - 22:00
+              </p>
+              <p className="flex items-center text-sm">
+                <IoTimeOutline className="mr-1" />
+                토-일: 10:30 - 22:00
+              </p>
+            </div>
+          </div>
+          <hr />
+          <div className="mb-4 mt-4">
+            <h2 className="mb-2 text-lg font-semibold">팝업스토어 소개</h2>
+            <p className="text-sm">{store?.description}</p>
+          </div>
+          <hr />
+          <div className="mt-4">
+            <h2 className="mb-4 text-lg font-semibold">상품 소개</h2>
+            <div className="flex justify-center">
+              <div className="grid grid-cols-2 gap-8">
+                {stores.map((store) => (
+                  <div
+                    key={store.id}
+                    className="cursor-pointer transition-transform duration-300 hover:scale-105"
+                    onClick={() => handleProductDetail(store.id)}
+                  >
+                    <Card
+                      variant="big"
+                      title={store.title}
+                      imageSrc={store.imageSrc}
+                    />
+                    <p className="text-sm">￦30,000원</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default StoreDetail;

--- a/frontend/src/pages/StoreSearch.tsx
+++ b/frontend/src/pages/StoreSearch.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Layout } from "../components/common/Layout";
+import { Tag } from "../components/common/Tag";
+import { SearchBar } from "../components/common/SearchBar";
+import { getStores } from "../mocks/store";
+import { Card } from "../components/common/Card";
+
+type SortOption = {
+  label: string;
+  value: string;
+};
+
+const sortOptions: SortOption[] = [
+  { label: "조회수 순", value: "views" },
+  { label: "최신 등록 순", value: "latest" },
+  { label: "운영 마감 임박 순", value: "soon" },
+];
+
+const StoreSearch = () => {
+  const navigate = useNavigate();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [isSearched, setIsSearched] = useState(false);
+
+  const [selectedSort, setSelectedSort] = useState<string>("views");
+  const [searchText, setSearchText] = useState("");
+  const stores = getStores();
+
+  useEffect(() => {
+    const query = searchParams.get("query") || "";
+    const sort = searchParams.get("sort") || "views";
+    console.log(query);
+    setSearchText(query);
+    setSelectedSort(sort);
+    setIsSearched(!!query);
+  }, [searchParams]);
+
+  const updateURL = (query: string, sort: string) => {
+    const newSearchParams = new URLSearchParams();
+    if (query) newSearchParams.set("query", query);
+    if (sort) newSearchParams.set("sort", sort);
+    setSearchParams(newSearchParams);
+  };
+
+  const handleSortChange = (value: string) => {
+    setSelectedSort(value);
+    updateURL(searchText, value);
+  };
+
+  const handleSearch = () => {
+    setIsSearched(true);
+    updateURL(searchText, selectedSort);
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchText(value);
+  };
+
+  const handleStoreDetail = (id: string) => {
+    navigate(`/store/detail/${id}`);
+  };
+
+  return (
+    <Layout>
+      <div className="flex min-h-screen flex-col">
+        <div className="mb-4">
+          <SearchBar
+            placeholder="스토어를 검색해보세요"
+            value={searchText}
+            onChange={handleSearchChange}
+            onSearch={handleSearch}
+          />
+        </div>
+        <div className="mb-4 ml-2">
+          {sortOptions.map((option) => (
+            <Tag
+              className="mr-1"
+              key={option.value}
+              content={option.label}
+              value={option.value}
+              isSelectable={true}
+              isSelected={selectedSort === option.value}
+              onClick={handleSortChange}
+            />
+          ))}
+        </div>
+        {/* 검색 결과 */}
+        {isSearched && (
+          <div>
+            {stores.map((store) => (
+              <div
+                className="cursor-pointer"
+                onClick={() => handleStoreDetail(store.id)}
+              >
+                <Card
+                  key={store.id}
+                  variant="store"
+                  title={store.title}
+                  subtitle={store.location}
+                  imageSrc={store.imageSrc}
+                  description={store.description}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+};
+
+export default StoreSearch;

--- a/frontend/src/routers/Routers.tsx
+++ b/frontend/src/routers/Routers.tsx
@@ -4,11 +4,17 @@ import HealthCheck from "../pages/HealthCheck";
 import Signup from "../pages/Signup";
 import SignupSuccess from "../pages/SignupSuccess";
 import PasswordSetup from "../pages/PasswordSetup";
+import Home from "../pages/Home";
+import StoreSearch from "../pages/StoreSearch";
+import StoreDetail from "../pages/StoreDetail";
 
 const Router = () => {
   return (
     <Routes>
       <Route path="/" element={<Main />} />
+      <Route path="/home" element={<Home />} />
+      <Route path="/search" element={<StoreSearch />} />
+      <Route path="/store/detail/:storeId" element={<StoreDetail />} />
       <Route path="/signup" element={<Signup />} />
       <Route path="/signup/success" element={<SignupSuccess />} />
       <Route path="/signup/password" element={<PasswordSetup />} />

--- a/frontend/src/types/store.d.ts
+++ b/frontend/src/types/store.d.ts
@@ -1,0 +1,10 @@
+export interface Store {
+  id: string;
+  title: string;
+  imageSrc: string;
+  location: string;
+  startDate: string;
+  endDate: string;
+  description: string;
+  imgScrList: string[];
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -166,5 +166,18 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    function ({ addUtilities }) {
+      const newUtilities = {
+        ".scrollbar-hide": {
+          "scrollbar-width": "none",
+          "-ms-overflow-style": "none",
+          "&::-webkit-scrollbar": {
+            display: "none",
+          },
+        },
+      };
+      addUtilities(newUtilities);
+    },
+  ],
 };


### PR DESCRIPTION
1. Home 페이지
- blob 추가
- 가로 스크롤(모바일만 가능)

![image](https://github.com/user-attachments/assets/cae34ffa-147c-4adc-9a94-095948d0382c)



2. 검색 페이지
- 태그 라디오 버튼 추가

![image](https://github.com/user-attachments/assets/82d4915b-e834-4775-9595-23399027ff29)


3. 스토어 상세 페이지
- carousel 추가(드래그 가능)
![image](https://github.com/user-attachments/assets/86867881-7c81-4272-9e4c-6384c11b55a5)
![image](https://github.com/user-attachments/assets/7fe9756e-8573-4efc-9999-92a31c21a678)